### PR TITLE
Added force engagements

### DIFF
--- a/UnitManager.h
+++ b/UnitManager.h
@@ -32,6 +32,7 @@ extern vector<Position> fleePositions;
 extern vector<Position> unitsFleeing;
 
 // Other
+extern bool forceEngage;
 extern int currentSize;
 extern vector<BWTA::Region*> allyTerritory;
 extern vector<Position> defendHere;
@@ -43,7 +44,7 @@ void unitGetCommand(Unit unit);
 void unitMicro(Unit unit);
 double unitGetStrength(Unit unit);
 Position unitRegroup(Unit unit);
-Position fleeFrom(Unit unit, Unit currentTarget);
+Position unitFlee(Unit unit, Unit currentTarget);
 void carrierManager(Unit unit);
 void shuttleManager(Unit unit);
 void shuttleHarass(Unit unit);


### PR DESCRIPTION
If close to ally territory, forces engagement to prevent fighting within chokepoint or having units attempt to move through chokepoint. Both result in units either not fighting, block other units or having a poor position to fight. This is most apparent when against Terran, so forcing an engagement might mean some tanks are unseiged and fight becomes winnable.